### PR TITLE
feat: Add About Us and Privacy Policy pages and update images

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -103,6 +103,8 @@
 				<li><a href="/">Homepage</a></li>
 				<li><a href="/sunnylink">sunnylink</a></li>
 				<li><a href="/dashboard">Dashboard</a></li>
+        <li><a href="/about-us">About Us</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
 			</ul>
 		</div>
 	</div>
@@ -209,14 +211,14 @@
 
 	<nav>
 		<h6 class="footer-title">Company</h6>
-		<a class="link link-hover">About us</a>
+        <a class="link link-hover" href="/about-us">About us</a>
 		<a class="link link-hover" href="https://github.com/sunnypilot/sunnypilot">Github</a>
 		<a class="link link-hover" href="https://discord.gg/sunnypilot">Discord</a>
 	</nav>
 	<nav>
 		<h6 class="footer-title">Legal</h6>
 		<a class="link link-hover">Terms of use</a>
-		<a class="link link-hover">Privacy policy</a>
+        <a class="link link-hover" href="/privacy-policy">Privacy policy</a>
 		<a class="link link-hover">Cookie policy</a>
 	</nav>
 </footer>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -109,8 +109,8 @@
 		<div class="card bg-base-100 w-full shadow-sm">
 			<figure class="px-6 pt-6">
 				<img
-					src="https://img.daisyui.com/images/stock/photo-1606107557195-0e29a4b5b4aa.webp"
-					alt="Shoes"
+					src="https://placehold.co/600x400/EEE/31343C?text=Dynamic+Experimental+Control"
+					alt="Dynamic Experimental Control"
 					class="w-full rounded-xl"
 				/>
 			</figure>
@@ -126,8 +126,8 @@
 		<div class="card bg-base-100 w-full shadow-sm">
 			<figure class="px-6 pt-6">
 				<img
-					src="https://img.daisyui.com/images/stock/photo-1606107557195-0e29a4b5b4aa.webp"
-					alt="Shoes"
+					src="https://placehold.co/600x400/EEE/31343C?text=MADS+Feature"
+					alt="MADS"
 					class="w-full rounded-xl"
 				/>
 			</figure>
@@ -143,8 +143,8 @@
 		<div class="card bg-base-100 w-full shadow-sm">
 			<figure class="px-6 pt-6">
 				<img
-					src="https://img.daisyui.com/images/stock/photo-1606107557195-0e29a4b5b4aa.webp"
-					alt="Shoes"
+					src="https://placehold.co/600x400/EEE/31343C?text=Forced+Car+Recognition"
+					alt="Forced Car Recognition"
 					class="w-full rounded-xl"
 				/>
 			</figure>

--- a/src/routes/about-us/+page.svelte
+++ b/src/routes/about-us/+page.svelte
@@ -1,0 +1,17 @@
+<div class="container mx-auto px-4 py-8">
+  <h1 class="text-4xl font-bold mb-4">About Us</h1>
+  <p class="text-lg mb-4">
+    Welcome to sunnypilot! We are passionate about creating innovative solutions
+    to enhance your driving experience. Our mission is to leverage cutting-edge
+    technology to deliver unparalleled development principles and stability.
+  </p>
+  <p class="text-lg mb-4">
+    Our team is composed of dedicated developers, designers, and enthusiasts
+    who are committed to community-driven development. We believe in transparency
+    and collaboration, and we strive to build a product that reflects the needs
+    and desires of our users.
+  </p>
+  <p class="text-lg">
+    Join us on our journey to redefine what's possible in driving assistance.
+  </p>
+</div>

--- a/src/routes/privacy-policy/+page.svelte
+++ b/src/routes/privacy-policy/+page.svelte
@@ -1,0 +1,52 @@
+<div class="container mx-auto px-4 py-8">
+  <h1 class="text-4xl font-bold mb-4">Privacy Policy</h1>
+  <p class="text-lg mb-4">
+    This Privacy Policy describes how your personal information is collected,
+    used, and shared when you use sunnypilot.
+  </p>
+
+  <h2 class="text-2xl font-semibold mb-2 mt-6">Information We Collect</h2>
+  <p class="text-lg mb-4">
+    We may collect information about your device, including information about
+    your web browser, IP address, time zone, and some of the cookies that are
+    installed on your device. Additionally, as you use the software, we may
+    collect information about how you interact with it.
+  </p>
+
+  <h2 class="text-2xl font-semibold mb-2 mt-6">How We Use Your Information</h2>
+  <p class="text-lg mb-4">
+    We use the information we collect to operate and maintain the features and
+    functionality of sunnypilot, to analyze how users interact with our software,
+    and to personalize your experience.
+  </p>
+
+  <h2 class="text-2xl font-semibold mb-2 mt-6">Sharing Your Information</h2>
+  <p class="text-lg mb-4">
+    We do not share your personal information with third parties except as
+    described in this Privacy Policy or as required by law. We may share
+    information with your consent, to comply with laws, or to protect our rights.
+  </p>
+
+  <h2 class="text-2xl font-semibold mb-2 mt-6">Your Rights</h2>
+  <p class="text-lg mb-4">
+    You may have certain rights regarding your personal information, including
+    the right to access, correct, or delete the personal information we hold
+    about you. Please contact us to exercise these rights.
+  </p>
+
+  <h2 class="text-2xl font-semibold mb-2 mt-6">Changes to This Policy</h2>
+  <p class="text-lg mb-4">
+    We may update this privacy policy from time to time in order to reflect,
+    for example, changes to our practices or for other operational, legal, or
+    regulatory reasons.
+  </p>
+
+  <h2 class="text-2xl font-semibold mb-2 mt-6">Contact Us</h2>
+  <p class="text-lg">
+    For more information about our privacy practices, if you have questions,
+    or if you would like to make a complaint, please contact us by e-mail at
+    privacy@example.com or by mail using the details provided below:
+    <br /><br />
+    [Your Company Address Here]
+  </p>
+</div>


### PR DESCRIPTION
- Creates new pages for "About Us" and "Privacy Policy" with initial content.
- Wires up these new pages in the header and footer navigation.
- Replaces placeholder images in the features section on the homepage with more descriptive ones using placehold.co.
- Updates alt text for the replaced images to improve accessibility.