### PR TITLE
fix: Update routing for coming soon and placeholder pages

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,7 +1,23 @@
+import { redirect, type Handle } from '@sveltejs/kit';
+import { sequence } from '@sveltejs/kit/hooks';
 import { handleLogto, UserScope } from '@logto/sveltekit';
 import { env } from '$env/dynamic/private';
 
-export const handle = handleLogto(
+const comingSoonRoutes: string[] = ['/terms-of-use', '/cookie-policy']; // MODIFIED LINE
+
+const handleRedirects: Handle = async ({ event, resolve }) => {
+  const { pathname } = event.url;
+
+  if (comingSoonRoutes.includes(pathname)) {
+    throw redirect(307, '/coming-soon');
+  }
+
+  // If no redirect, proceed as normal
+  const response = await resolve(event);
+  return response;
+};
+
+const handleLogtoAuth = handleLogto(
 	{
 		endpoint: env.LOGTO_ENDPOINT,
 		appId: env.LOGTO_APP_ID,
@@ -12,3 +28,5 @@ export const handle = handleLogto(
 		encryptionKey: env.LOGTO_COOKIE_ENCRYPTION_KEY ?? ''
 	}
 );
+
+export const handle = sequence(handleRedirects, handleLogtoAuth);

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,0 +1,27 @@
+<script>
+  import { page } from '$app/stores';
+  import { base } from '$app/paths';
+</script>
+
+<div class="error-container">
+  <img src="{base}/../src/lib/images/smiling-astro.png" alt="Cute Error Image" />
+  <h1>Oops! {$page.status}</h1>
+  <p>{$page.error?.message}</p>
+  <p>Sorry, the page you are looking for does not exist.</p>
+  <a href="{base}/">Go back to Homepage</a>
+</div>
+
+<style>
+  .error-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 80vh;
+    text-align: center;
+  }
+  img {
+    max-width: 200px;
+    margin-bottom: 20px;
+  }
+</style>

--- a/src/routes/coming-soon/+page.svelte
+++ b/src/routes/coming-soon/+page.svelte
@@ -1,0 +1,26 @@
+<script>
+  import { base } from '$app/paths';
+</script>
+
+<div class="coming-soon-container">
+  <img src="{base}/../src/lib/images/astronaut.png" alt="Cute Coming Soon Image" />
+  <h1>Coming Soon!</h1>
+  <p>We're working hard to bring this page to you.</p>
+  <p>Please check back later!</p>
+  <a href="{base}/">Go back to Homepage</a>
+</div>
+
+<style>
+  .coming-soon-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 80vh;
+    text-align: center;
+  }
+  img {
+    max-width: 200px;
+    margin-bottom: 20px;
+  }
+</style>


### PR DESCRIPTION
This commit refines the behavior of "coming soon" and 404 pages based on your feedback.

Key changes:
- Corrected `src/hooks.server.ts`:
    - Removed `/about-us` and `/privacy-policy` from the list of routes that redirect to `/coming-soon`. These pages will now load their actual content.
    - Added `/terms-of-use` and `/cookie-policy` to the `comingSoonRoutes` list. Navigating to these paths will now redirect to the `/coming-soon` page. This is based on identifying "Terms of use" and "Cookie policy" links in the footer (within `src/routes/+layout.svelte`) as placeholders.

- The custom 404 page (`src/routes/+error.svelte`) continues to handle truly non-existent paths.
- The "coming soon" page (`src/routes/coming-soon/+page.svelte`) is used for the explicitly designated placeholder routes.

This aligns the application's navigation behavior more closely with the intended experience for WIP sections and actual content pages.