### PR TITLE
Fix SPA build for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-sunnylink
+# sunnylink
+
+This repo hosts the SvelteKit code for the sunnylink SPA. The project is
+published via GitHub Pages under the `/sunnylink-svelte` path. To create a
+build for GitHub Pages run:
+
+```bash
+pnpm install
+pnpm build
+```
+
+The `adapter-static` configuration uses `404.html` as the fallback file and
+server-side rendering is disabled. This allows GitHub Pages to serve the app as
+a single page application without server side routing.

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -3,13 +3,17 @@ import adapter from '@sveltejs/adapter-static';
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		adapter: adapter({
-			fallback: 'index.html'
-		}),
-		paths: {
-			base: '/sunnylink-svelte'
-		}
-	}
+               adapter: adapter({
+                       // Use a 404.html fallback so Github Pages can serve
+                       // our single page application without server routing
+                       fallback: '404.html'
+               }),
+               paths: {
+                       base: '/sunnylink-svelte'
+               },
+               // Disable server side rendering so the build works as a pure SPA
+               ssr: false
+       }
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- update SvelteKit static adapter to emit `404.html` as SPA fallback
- disable SSR to ensure client-only rendering
- document GitHub Pages build steps

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9c42ccc0832186a2f47a213b7735