### PR TITLE
Fix SPA build for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-sunnylink
+# sunnylink
+
+This repo hosts the SvelteKit code for the sunnylink SPA. The project is
+published via GitHub Pages under the `/sunnylink-svelte` path. To create a
+build for GitHub Pages run:
+
+```bash
+pnpm install
+pnpm build
+```
+
+The static adapter emits a `404.html` file so that GitHub Pages can redirect all
+routes back to the SPA entry. Server-side rendering is disabled in
+`src/routes/+layout.ts` to ensure the site runs completely on the client.

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,0 +1,2 @@
+export const ssr = false;
+

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -3,13 +3,16 @@ import adapter from '@sveltejs/adapter-static';
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		adapter: adapter({
-			fallback: 'index.html'
-		}),
-		paths: {
-			base: '/sunnylink-svelte'
-		}
-	}
+               adapter: adapter({
+                       // Use a 404.html fallback so Github Pages can serve
+                       // our single page application without server routing
+                       fallback: '404.html'
+               }),
+               paths: {
+                       base: '/sunnylink-svelte'
+               },
+               // Build purely static files. SSR is disabled at the route level
+       }
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- disable SSR at route level
- update static adapter comment
- document GitHub Pages build steps

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9c42ccc0832186a2f47a213b7735